### PR TITLE
The never ending stories of engine migrations

### DIFF
--- a/lib/active_currency/engine.rb
+++ b/lib/active_currency/engine.rb
@@ -7,7 +7,7 @@ module ActiveCurrency
     initializer :append_migrations do |app|
       next if app.root.to_s.match(root.to_s)
 
-      paths = ActiveRecord::Migrator.migrations_paths
+      paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
       config.paths['db/migrate'].expanded.each do |path|
         paths << path
       end


### PR DESCRIPTION
Les injections de migrations via le 💀  `MIGRATOR` 💀  ne fonctionnent pas bien sur un `migrate` ou bien sur un `schema:load` en isolation. Ça ne fonctionne correctement que couplé avec un `rake db:create`.

Les injections fonctionnent bien en utilisant plutôt `Tasks::DatabaseTasks`. Et c'est compliqué à expliquer parce que le code d'ActiveRecord n'est pas franchement simple 😬 