### PR TITLE
Make RateStore marshalable (add #marshal_dump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning].
 Changes:
 - Drop support for Rails < 7.0.
 
+Fix:
+- Make `RateStore` marshalable so a bank using it can be marshaled.
+
 ## v1.4.1
 
 Fix:

--- a/lib/active_currency/rate_store.rb
+++ b/lib/active_currency/rate_store.rb
@@ -3,5 +3,15 @@
 module ActiveCurrency
   class RateStore < DatabaseStore
     include CacheableStore
+
+    # Money::Bank::VariableExchange#marshal_load rebuilds the store with
+    # `store_info.shift.new(*store_info)`, so a store's #marshal_dump must
+    # return `[StoreClass, *constructor_args]`. RateStore takes no arguments,
+    # so returning `[self.class]` lets a bank backed by this store be
+    # marshaled -- for example when the configured default bank is cached
+    # under a Marshal-based cache/serializer.
+    def marshal_dump
+      [self.class]
+    end
   end
 end

--- a/spec/lib/active_currency/rate_store_spec.rb
+++ b/spec/lib/active_currency/rate_store_spec.rb
@@ -104,4 +104,18 @@ RSpec.describe ActiveCurrency::RateStore do
       end
     end
   end
+
+  describe "#marshal_dump" do
+    it "dumps the class so the store can be rebuilt on load" do
+      expect(store.marshal_dump).to eq([described_class])
+    end
+
+    it "lets a bank backed by the store round-trip through Marshal" do
+      bank = Money::Bank::VariableExchange.new(store)
+
+      loaded = Marshal.load(Marshal.dump(bank))
+
+      expect(loaded.store).to be_a(described_class)
+    end
+  end
 end


### PR DESCRIPTION
### Problem

Marshaling a `Money::Bank::VariableExchange` whose store is an
`ActiveCurrency::RateStore` fails, because `RateStore` has no `#marshal_dump`.

`VariableExchange#marshal_load` rebuilds the store with:

```ruby
@store = store_info.shift.new(*store_info)
```

so it expects the store's `#marshal_dump` to return
`[StoreClass, *constructor_args]`. Without a custom `#marshal_dump`,
reloading a marshaled bank raises.

This comes up when the configured `default_bank` uses a `RateStore` and
something marshals it, e.g. a Rails app with a Marshal-based cache or
message serializer that caches the default bank.

### Fix

Add `#marshal_dump` to `RateStore` returning `[self.class]`. `RateStore`
takes no constructor arguments, so that is all `VariableExchange#marshal_load`
needs to rebuild it on load.

### Test

Added specs asserting `RateStore#marshal_dump` returns `[described_class]`
and that a `VariableExchange` backed by a `RateStore` round-trips through
`Marshal`.
