### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
@sunny I asked Claude about the CI problem because I don't know a lot about Github Actions 🙈 That said, I confirmed the changes with [the official documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories) and confirmed we have the same setup in other RubyMoney repos like, for example, [`money`](https://github.com/RubyMoney/money/blob/main/.github/workflows/ruby.yml#L3-L10) 😊 

⬇️ Claude description 

The `Test` workflow triggered on `on: [push]` only. **For a pull request from a fork the push event fires on the contributor's repo, not on this one, so fork PRs never ran any checks at all** — #31 has been sitting with an empty status check list since it was opened.

This switches the trigger to `push` + `pull_request` scoped to `main`, which is the pattern already used by every other repo in the RubyMoney org (`money`, `money-rails`, `monetize`, `eu_central_bank`, `money-collection`, `money-heuristics`). It also adds the `permissions: contents: read` block those repos carry, and bumps `actions/checkout` from v3 to v7 to match them.