### PR TITLE
Remove deprecated rake statistics

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+# Bundler
+
 begin
   require "bundler/setup"
 rescue LoadError
   puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
+
+require "bundler/gem_tasks"
+
+# RDoc
 
 require "rdoc/task"
 
@@ -16,12 +22,12 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
+# Rails dummy app
+
 APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
 
-load "rails/tasks/statistics.rake"
-
-require "bundler/gem_tasks"
+# RSpec
 
 begin
   require "rspec/core/rake_task"
@@ -29,6 +35,8 @@ begin
 rescue LoadError
   puts "RSpec load error"
 end
+
+# RuboCop
 
 require "rubocop/rake_task"
 


### PR DESCRIPTION
> DEPRECATION WARNING: rails/tasks/statistics.rake is deprecated and will be removed in Rails 8.2 without replacement.
